### PR TITLE
[cloudhopper]Fixed Flaky Tests in MetaField,MetaFieldUtil and MetaFieldUtilTest

### DIFF
--- a/ch-commons-util/pom.xml
+++ b/ch-commons-util/pom.xml
@@ -58,4 +58,19 @@
     <slf4j.version>1.7.21</slf4j.version>
     <logback.version>1.1.7</logback.version>
   </properties>
+
+  <build>
+    <plugins>
+        <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-compiler-plugin</artifactId>
+            <version>3.8.0</version>
+            <configuration>
+                <source>1.8</source>
+                <target>1.8</target>
+            </configuration>
+        </plugin>
+    </plugins>
+</build>
+
 </project>

--- a/ch-commons-util/src/main/java/com/cloudhopper/commons/util/MetaFieldUtil.java
+++ b/ch-commons-util/src/main/java/com/cloudhopper/commons/util/MetaFieldUtil.java
@@ -22,7 +22,12 @@ package com.cloudhopper.commons.util;
 
 import java.lang.reflect.Field;
 import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Comparator;
+import java.util.List;
 import java.util.concurrent.atomic.AtomicReference;
+import java.util.stream.Collectors;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import com.cloudhopper.commons.util.annotation.MetaField;
@@ -172,8 +177,14 @@ public class MetaFieldUtil {
         // keep searching up until we reach an Object class type
         for (Class classType : hierarchy) {
             
+            List<Field> sortedFields = Arrays.stream(classType.getDeclaredFields())
+                .filter(f -> f.isAnnotationPresent(MetaField.class))
+                .sorted(Comparator.comparingInt(f -> f.getAnnotation(MetaField.class).order()))
+                .collect(Collectors.toList());
+
             // begin search for each field (variable)
-            for (Field f : classType.getDeclaredFields()) {
+            for (Field f : sortedFields) {
+            
 
                 // is this field marked as a MetaField?
                 if (f.isAnnotationPresent(MetaField.class)) {

--- a/ch-commons-util/src/main/java/com/cloudhopper/commons/util/annotation/MetaField.java
+++ b/ch-commons-util/src/main/java/com/cloudhopper/commons/util/annotation/MetaField.java
@@ -39,6 +39,7 @@ public @interface MetaField {
     String name() default "";
     /** Description of field */
     String description() default "";
+    int order() default Integer.MAX_VALUE; // New property
     /** Level of field (matches what Log4J uses by name */
     Level level() default Level.INFO;
 }

--- a/ch-commons-util/src/test/java/com/cloudhopper/commons/util/MetaFieldUtilTest.java
+++ b/ch-commons-util/src/test/java/com/cloudhopper/commons/util/MetaFieldUtilTest.java
@@ -127,17 +127,17 @@ class TestRef {
 }
 
 class Person {
-    @MetaField(name="First Name", description="The first name of this user")
+    @MetaField(name="First Name", description="The first name of this user", order = 1)
     private String firstName;
-    @MetaField(name="Last Name", description="")
+    @MetaField(name="Last Name", description="", order = 2)
     private String lastName;
-    @MetaField
+    @MetaField(order = 3)
     private String email;
-    @MetaField(name="ID")
+    @MetaField(name="ID", order = 4)
     private int id = -1;
-    @MetaField(name="Active?", description="Is this person actually active")
+    @MetaField(name="Active?", description="Is this person actually active", order = 5)
     private AtomicBoolean isActive = new AtomicBoolean(false);
-    @MetaField(description="Number of times logged in")
+    @MetaField(description="Number of times logged in", order = 6)
     private AtomicInteger loginCounter = new AtomicInteger(0);
 
     public void setFirstName(String value) { firstName = value; }


### PR DESCRIPTION
# What is the purpose of this PR
* This PR fixes the error resulting from a flaky test: `com.cloudhopper.commons.util.MetaFieldUtilTest.toMetaFieldInfoArray`
# Why the test failed
The MetaFieldUtil.toMetaFieldInfoArray method doesn't return the field information correctly.
The `toMetaFieldInfoArray` test failed when trying to validate the value of `fields[0].name`. The expected value was "First Name", but it was actually "ID".
# Reproduce the test failure
Run the tests with NonDex maven plugin. You can reproduce it by using the following instruction:
`mvn -pl ch-commons-util edu.illinois:nondex-maven-plugin:2.1.1:nondex -Dtest=com.cloudhopper.commons.util.MetaFieldUtilTest#toMetaFieldInfoArray`
# Fix
Add a new property in `MetaField` and then use it to sort `MetaFieldInfo` array, so that we can fix the error of method `toMetaFieldInfoArray`.